### PR TITLE
Fixes Table Icon Knocked Out of Place

### DIFF
--- a/css/map_explorer.css
+++ b/css/map_explorer.css
@@ -224,7 +224,7 @@ body.page-template-page-map-explorer{overflow: hidden;}
  content:none !important;
 }
 .layer-item .layer-item-name{
-  max-width: 68%;
+  max-width: 65%;
   display: inline-table;
 }
 


### PR DESCRIPTION
Fixed issue: https://github.com/OpenDevelopmentMekong/opendev-wptheme/issues/837
