### PR TITLE
enhance styling of Feature Box

### DIFF
--- a/css/opendev.css
+++ b/css/opendev.css
@@ -1831,11 +1831,43 @@ a.button:hover{
 .wp-feature-box{
     margin-bottom: 20px;
 }
+.wp-feature-box .list-group-links{
+  margin: 15px 0;
+}
+.wp-feature-box .list-group-links li, .wp-feature-box .wp-feature-box-link-group ul li{
+  list-style-type: none !important;
+  margin: 0
+}
 #featured-media .map-container,
 #featured-media .mapgroup-container {
  height: 100%;
 }
 
+.wp-feature-box .list-group-links li a{
+  display: block;
+  padding: 10px 5px;
+  font-size: 12px;
+  line-height: 18px;
+  border-bottom: 1px dotted rgba(255,255,255,0.3);
+  border-left: 1px dotted rgba(255,255,255,0.3);
+  border-right: 1px dotted rgba(255,255,255,0.3);
+  max-width: 300px;
+  margin: 0 auto;
+  text-decoration: none;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+}
+.wp-feature-box .list-group-links li:first-child a {
+    border-top: 1px dotted rgba(255,255,255,0.3);
+}
+.wp-feature-box .list-group-links li a:hover{
+	text-decoration: none;
+	background: rgba(0,0,0,0.8);
+}
+.wp-feature-box .wp-feature-box-header{
+  position: relative;
+  z-index: 5;
+}
 
 /*
  * page


### PR DESCRIPTION
Fixs this issue: https://github.com/OpenDevelopmentMekong/opendev-wptheme/issues/931
Code or also updated to be able to add multiple link in feature box. 

@DBishton, please add this class to UL tag: "list-group-links".  To add it, Go to 
Tool -> Source code: 
eg.

<ul class="list-group-links">
<li><a href="http://sfasd">AAAAA</a></li>
....
<li><a href="http://sdfas">EEEE</a></li>
</ul>
